### PR TITLE
Added protection for POST and now sending connection close properly

### DIFF
--- a/config/server.conf
+++ b/config/server.conf
@@ -9,7 +9,7 @@ server {
     # Default error pages
     # error_page 404 root/etc/response/404.html;
     error_page 404 /root/etc/ServerResp/404.html;
-	error_page 401 /root/etc/Resp/404.html;
+	# error_page 401 /root/etc/Resp/401.html;
     error_page 500 /errors/500.html;
 
     # Limit client body size (bytes, kilobytes(K,k) or megabytes(M,m))

--- a/include/webserv.hpp
+++ b/include/webserv.hpp
@@ -19,7 +19,7 @@
 #include <dirent.h>
 #include "../src/Logger/Logger.hpp"
 
-
+#define MAX_DIRECTORY_SIZE 500000000
 #define MAX_BODY_SIZE 9000000
 #define GET 1
 #define POST 2

--- a/src/Response/Response.cpp
+++ b/src/Response/Response.cpp
@@ -61,6 +61,8 @@ std::string Response::getResponseCodeStr()
 		return(status += "502 Bad Gateway\n");		
 	case 503:
 		return(status += "503 Service Unavailable\n");
+	case 507:
+		return(status += "507 Insufficient Storage\n");
 	default:
 		return(status += std::to_string(_responseCode) + "\n");
 	}
@@ -174,6 +176,7 @@ void Response::sendResponse(int fd)
 	
 	//uncomment this in order to see the response in the terminal
 	//std::cout <<  _buffer << std::endl;
+	
 	try
 	{
 		send(fd, _buffer.c_str(), _buffer.size(), 0);

--- a/src/Response/ServerHandler.hpp
+++ b/src/Response/ServerHandler.hpp
@@ -45,4 +45,5 @@ public:
 	void 	responseCode(int code);
 	void 	checkPath();
 	bool	isReadable(std::string path);
+	int		checkDirectorySize(std::filesystem::path path);
 };


### PR DESCRIPTION
When POST is made it checks the size of the directory and compares it to a MAX size set in the main header, if it is larger, it will not allow post until space is freed up. Also echoes a Connection: close back to the client correctly.